### PR TITLE
Return which movie was being processed when it fails

### DIFF
--- a/delete.movies.unwatched.py
+++ b/delete.movies.unwatched.py
@@ -115,8 +115,11 @@ try:
                         totalsize = totalsize + purge(movie)
 except Exception as e:
     print(
-        "ERROR: There was a problem connecting to Tautulli/Radarr/Overseerr. Please double-check that your connection settings and API keys are correct.\n\nError message:\n"
-        + str(e)
+        f"ERROR: There was a problem processing {movie['title']}.",
+        "This could be whilst connecting to Tautulli/Radarr/Overseerr.",
+        "Please double-check that your connection settings and API keys are correct.",
+        "\nError message:",
+        str(e)
     )
     sys.exit(1)
 


### PR DESCRIPTION
I found that sometimes the script will fail with errors like `list index out of range`. However, there's no way to tell what item was being processed when it fails.

This MR simply adds the movie's title into the error message.