### PR TITLE
Gracefully handle missing tmdb guids

### DIFF
--- a/delete.movies.unwatched.py
+++ b/delete.movies.unwatched.py
@@ -115,8 +115,11 @@ try:
                         totalsize = totalsize + purge(movie)
 except Exception as e:
     print(
-        "ERROR: There was a problem connecting to Tautulli/Radarr/Overseerr. Please double-check that your connection settings and API keys are correct.\n\nError message:\n"
-        + str(e)
+        f"ERROR: There was a problem processing {movie['title']}.",
+        "This could be whilst connecting to Tautulli/Radarr/Overseerr.",
+        "Please double-check that your connection settings and API keys are correct.",
+        "\nError message:",
+        str(e)
     )
     sys.exit(1)
 

--- a/delete.movies.unwatched.py
+++ b/delete.movies.unwatched.py
@@ -31,6 +31,10 @@ def purge(movie):
 
     guids = jq.compile(".[].data.guids").input(r.json()).first()
 
+    if len(guids) == 0:
+       print(f"Ignoring '{movie['title']}' as could not find GUID in TMDB for it.");
+       return 0
+
     tmdbid = [i for i in guids if i.startswith("tmdb://")][0].split("tmdb://", 1)[1]
 
     f = requests.get(f"{c.radarrHost}/api/v3/movie?apiKey={c.radarrAPIkey}")


### PR DESCRIPTION
Not finding a GUID in the TMDB lookup causes an error `list index out of range` to be raised. This MR catches that issue and skips processing the item