### PR TITLE
Fix sonarr escape problems

### DIFF
--- a/delete.tv.unwatched.py
+++ b/delete.tv.unwatched.py
@@ -43,7 +43,7 @@ def purge(series):
             )
         else:
             sonarr = (
-                jq.compile(f".[] | select(.title == {series['title']})")
+                jq.compile(f".[] | select(.title == \"{series['title']}\")")
                 .input(f.json())
                 .first()
             )


### PR DESCRIPTION
Quoting show titles to resolve JQ issues when parsing. Example:

`ERROR: Burden of Truth: jq: error: syntax error, unexpected IDENT, expecting ';' or ')' (Unix shell quoting issues?) at <top-level>, line 1:
.[] | select(.title == Burden of Truth)                              
jq: 1 compile error`

