### PR TITLE
sonarr/radarr delete validation changes

### DIFF
--- a/delete.movie.py
+++ b/delete.movie.py
@@ -61,6 +61,8 @@ def purge(movie):
                 + str(radarr["id"])
                 + f"?apiKey={c.radarrAPIkey}&deleteFiles=true"
             )
+            if len(response.content) >= 2:
+                raise Exception("Response body size is (" + str(len(response.content)) + ") - movie may not have deleted. Check that the configured Radarr URL base is correct!")
 
         try:
             if not c.dryrun and c.overseerrAPIkey is not None:

--- a/delete.movies.unwatched.py
+++ b/delete.movies.unwatched.py
@@ -57,6 +57,8 @@ def purge(movie):
                 + str(radarr["id"])
                 + f"?apiKey={c.radarrAPIkey}&deleteFiles=true"
             )
+            if len(response.content) >= 2:
+                raise Exception("Response body size is (" + str(len(response.content)) + ") - movie may not have deleted. Check that the configured Radarr URL base is correct!")
 
         try:
             if not c.dryrun and c.overseerrAPIkey is not None:

--- a/delete.tv.unwatched.py
+++ b/delete.tv.unwatched.py
@@ -57,6 +57,8 @@ def purge(series):
                 + str(sonarr["id"])
                 + f"?apiKey={c.sonarrAPIkey}&deleteFiles=true"
             )
+            if len(response.content) >= 2:
+                raise Exception("Response body size is (" + str(len(response.content)) + ") - series may not have deleted. Check that the configured Sonarr URL base is correct!")
 
         try:
             if not c.dryrun and c.overseerrAPIkey is not None:


### PR DESCRIPTION
I have discovered (might be an issue on my particular setup) that when running radarr/sonarr with a configured url base, the respective apis behave in an odd fashion upon a `delete` request.

If the configured url path in the .env file is missing the respective `/sonarr` or `/radarr` path, a `delete` request will successfully return a 200 along with a payload of the series/movie in question but will not delete it from the system.  

The current logic in the code assumes that the payload has been deleted and tallies up into the summary at the end as reclaimed space, where it's not actually done anything.

This fix (arguably a bit of a kludge) checks the length of the call response and raises an exception if its longer than expected (i.e. not `{}`)

example error message returned:

```
ERROR: The Batman: Response body size is larger than expected (5057) - movie may not have deleted. Check that the Radarr base url is correct!
Total space reclaimed: 0.00GB
```