### PR TITLE
Adding protected tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ OVERSEERR_API=abcdefghijklmnopqrstuvwxyz987654=
 
 # Define protected tag ids for Radarr and Sonarr. 
 # Content tagged with these will not be deleted automatically
+# Please use the tag IDs and not the tag names! 
+# You can find them by browsing to http://<Radarr|Sonarr>/api/v3/tag?apikey=<API-Key>
 # Multiple tags can be seperated by comma. Set to 0 or leave blank to disable
 RADARR_PROTECTED_TAGS=0
 SONARR_PROTECTED_TAGS=0

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ OVERSEERR_API=abcdefghijklmnopqrstuvwxyz987654=
 #TAUTULLI_MOVIE_SECTIONID=1
 #TAUTULLI_TV_SECTIONID=2
 
+# Define protected tag ids for Radarr and Sonarr. 
+# Content tagged with these will not be deleted automatically
+# Multiple tags can be seperated by comma. Set to 0 or leave blank to disable
+RADARR_PROTECTED_TAGS=0
+SONARR_PROTECTED_TAGS=0
+
 # Number of rows to pull from Tautulli's media table.
 #TAUTULLI_NUM_ROWS=3000
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ An example of the contents of a `protected` file:
 
 Note: because the `protected` file uses TMDB & TVDB IDs, there is a possibility of overlap. If you're concerned about this, I suggest you create separate files for running with the TV and movie deletes, i.e. `-v /home/user/protectedtv:/app/protected` and `-v /home/user/protectedmovies:/app/protected`.
 
+### Protected Tags
+
+Additionally, you may also specify tags from Radarr/Sonarr for which content must not be deleted. Those tags can be provided as a comma-seperated list of IDs (**not tag names!**) using the `RADARR_PROTECTED_TAGS` and `SONARR_PROTECTED_TAGS` environment variables. That's a great way to simplify protecting specific media - you might also use the automated tagging feature within Radarr/Sonarr to automatically protect media matching specific criteria.
+
+The best way to get the corresponding tag IDs is to simply browse to http://\<Radarr|Sonarr\>/api/v3/tag?apikey=\<Your API-Key\> - The output should look like this:
+
+```json
+[
+  {
+    "label": "rssimport",
+    "id": 21
+  },
+  {
+    "label": "example",
+    "id": 22
+  },
+  {
+    "label": "noautodelete",
+    "id": 26
+  }
+]
+```
+
+If we'd like to exclude the tags "example" and "noautodelete", we'd set `<RADARR|SONARR>_PROTECTED_TAGS=22,26`. 
+
 ### Alternate usage
 
 If you wish, you can also run the python code yourself. This code has been tested on python 3.10 and 3.11.
@@ -146,7 +171,11 @@ The scripts use the following environment variables for configuration:
 
 - `OVERSEERR`: The URL & port of your Overseerr installation, e.g. `http://localhost:5055`
 
-- `OVERSEERR_API`: The API key for accessing your Overseerr installation. Be sure to comment out the Overseerr connection variables in your `.env` file if you don't use Overseerr. It will keep your logs neat. 
+- `OVERSEERR_API`: The API key for accessing your Overseerr installation. Be sure to comment out the Overseerr connection variables in your `.env` file if you don't use Overseerr. It will keep your logs neat.
+ 
+- `RADARR_PROTECTED_TAGS`: A comma-seperated list of Radarr tag IDs to dynamically exclude content from deletion. Browse to http://\<Radarr\>/api/v3/tag?apikey=\<Your API-Key\> to see the IDs corresponding to your tags. Movies containing that tag will not be deleted. Leave blank or set to 0 to disable.
+
+- `RADARR_PROTECTED_TAGS`: A comma-seperated list of Sonarr tag IDs to dynamically exclude content from deletion. Browse to http://\<Sonarr\>/api/v3/tag?apikey=\<Your API-Key\> to see the IDs corresponding to your tags. Shows containing that tag will not be deleted. Leave blank or set to 0 to disable.
 
 - `TAUTULLI_MOVIE_SECTIONID`: Default: 1. The section ID in Tautulli containing watch history metadata of movies. You can get this by going to Tautulli, clicking "Libraries," then clicking the library you want to use. Look at the URL bar and you'll see "library?section_id=". You want the number after "section_id=".
 

--- a/config.py
+++ b/config.py
@@ -23,6 +23,7 @@ class Config:
         self.radarrProtectedTags = os.getenv("RADARR_PROTECTED_TAGS")
         self.sonarrHost = os.getenv("SONARR", "http://localhost:8989")
         self.sonarrAPIkey = os.getenv("SONARR_API")
+        self.sonarrProtectedTags = os.getenv("SONARR_PROTECTED_TAGS")
         if self.dryrun:
             print("DRY_RUN enabled!")
 

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ class Config:
         self.dryrun = os.getenv("DRY_RUN", None) != None
         self.radarrHost = os.getenv("RADARR", "http://localhost:7878")
         self.radarrAPIkey = os.getenv("RADARR_API")
+        self.radarrProtectedTags = os.getenv("RADARR_PROTECTED_TAGS")
         self.sonarrHost = os.getenv("SONARR", "http://localhost:8989")
         self.sonarrAPIkey = os.getenv("SONARR_API")
         if self.dryrun:

--- a/delete.movies.unwatched.py
+++ b/delete.movies.unwatched.py
@@ -20,6 +20,8 @@ if os.path.exists("./protected"):
         while line := file.readline():
             protected.append(int(line.rstrip()))
 
+protected_tags = [int(i) for i in c.radarrProtectedTags.split(",")]
+
 print("--------------------------------------")
 print(datetime.now().isoformat())
 
@@ -59,6 +61,9 @@ def purge(movie):
             )
 
         if radarr["tmdbId"] in protected:
+            return deletesize
+
+        if any(e in protected_tags for e in radarr["tags"]):
             return deletesize
 
         if not c.dryrun:

--- a/delete.movies.unwatched.py
+++ b/delete.movies.unwatched.py
@@ -20,7 +20,11 @@ if os.path.exists("./protected"):
         while line := file.readline():
             protected.append(int(line.rstrip()))
 
-protected_tags = [int(i) for i in c.radarrProtectedTags.split(",")]
+try:
+    protected_tags = [int(i) for i in c.radarrProtectedTags.split(",")]
+except Exception as e:
+    protected_tags = []
+
 
 print("--------------------------------------")
 print(datetime.now().isoformat())

--- a/delete.tv.unwatched.py
+++ b/delete.tv.unwatched.py
@@ -15,7 +15,10 @@ c.apicheck(c.sonarrHost, c.sonarrAPIkey)
 
 protected = []
 
-protected_tags = [int(i) for i in c.sonarrProtectedTags.split(",")]
+try:
+    protected_tags = [int(i) for i in c.sonarrProtectedTags.split(",")]
+except Exception as e:
+    protected_tags = []
 
 if os.path.exists("./protected"):
     with open("./protected", "r") as file:

--- a/delete.tv.unwatched.py
+++ b/delete.tv.unwatched.py
@@ -15,6 +15,8 @@ c.apicheck(c.sonarrHost, c.sonarrAPIkey)
 
 protected = []
 
+protected_tags = [int(i) for i in c.sonarrProtectedTags.split(",")]
+
 if os.path.exists("./protected"):
     with open("./protected", "r") as file:
         while line := file.readline():
@@ -60,6 +62,9 @@ def purge(series):
             )
 
         if sonarr["tvdbId"] in protected:
+            return deletesize
+
+        if any(e in protected_tags for e in sonarr["tags"]):
             return deletesize
 
         if not c.dryrun:


### PR DESCRIPTION
Hi,

this is just an additional feature I personally think is quite useful. With protected tags, you can simply provide one or more tag IDs from Radarr and Sonarr. If a movie or series is tagged with one of these, purgeomatic will skip deletion.
 
Currently you're only able to set up a list in the "protected" file which requires additional steps when it comes to automatically protecting content. With protected tags, you can simply use the automated tagging engine already built in to Radarr and Sonarr, making life just a bit easier :-)